### PR TITLE
Rework spackbot: security fixes and use a team for maintainers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.9
+FROM python:3.7
+
+EXPOSE 8080
 
 COPY requirements.txt .
 COPY spackbot /app/spackbot

--- a/spackbot/__main__.py
+++ b/spackbot/__main__.py
@@ -19,7 +19,7 @@ from . import pr_add_labels, pr_add_reviewers
 # take environment variables from .env file (if present)
 load_dotenv()
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 
 #: Location for authenticatd app to get a token for one of its installations
 INSTALLATION_TOKEN_URL = "app/installations/{installation_id}/access_tokens"

--- a/spackbot/pr_add_labels.py
+++ b/spackbot/pr_add_labels.py
@@ -136,7 +136,7 @@ async def label_pull_requests(event, gh, *args, session, **kwargs):
     """Add labels to PRs based on which files were modified."""
     pull_request = event.data["pull_request"]
     number = event.data["number"]
-    logger.debug(f"Labeling PR #{number}...")
+    logger.info(f"Labeling PR #{number}...")
 
     # Iterate over modified files and create a list of labels
     # https://developer.github.com/v3/pulls/#list-pull-requests-files
@@ -144,8 +144,8 @@ async def label_pull_requests(event, gh, *args, session, **kwargs):
     async for file in gh.getiter(pull_request["url"] + "/files"):
         filename = file["filename"]
         status = file["status"]
-        logger.debug(f"Filename: {filename}")
-        logger.debug(f"Status: {status}")
+        logger.info(f"Filename: {filename}")
+        logger.info(f"Status: {status}")
 
         # Add our own "package" attribute to the file, if it's a package
         match = re.match(
@@ -164,7 +164,7 @@ async def label_pull_requests(event, gh, *args, session, **kwargs):
             if all(attr_matches):
                 labels.append(label)
 
-    logger.debug(f"Adding the following labels: {labels}")
+    logger.info(f"Adding the following labels: {labels}")
 
     # https://developer.github.com/v3/issues/labels/#add-labels-to-an-issue
     if labels:

--- a/spackbot/pr_add_reviewers.py
+++ b/spackbot/pr_add_reviewers.py
@@ -101,13 +101,13 @@ def find_maintainers(packages, repository, pull_request, number):
         from sh import spack
 
         for package in packages:
-            logger.debug(f"Package: {package}")
+            logger.info(f"Package: {package}")
 
             # Query maintainers
             pkg_maintainers = spack("maintainers", package, _ok_code=(0, 1)).split()
             pkg_maintainers = set(pkg_maintainers)
 
-            logger.debug("Maintainers: %s" % ", ".join(sorted(pkg_maintainers)))
+            logger.info("Maintainers: %s" % ", ".join(sorted(maintainers)))
 
             if not pkg_maintainers:
                 without_maintainers.append(package)
@@ -139,7 +139,7 @@ async def add_reviewers(gh, repository, pull_request, number):
 
     If a package does not have any maintainers yet, request them.
     """
-    logger.debug(f"Looking for reviewers for PR #{number}...")
+    logger.info(f"Looking for reviewers for PR #{number}...")
 
     packages = await changed_packages(gh, pull_request)
 
@@ -158,7 +158,7 @@ async def add_reviewers(gh, repository, pull_request, number):
         reviewers = []
         non_reviewers = []
         for user in maintainers:
-            logger.debug(f"User: {user}")
+            logger.info(f"User: {user}")
 
             collaborators_url = repository["collaborators_url"]
             if not await found(gh.getitem(collaborators_url, {"collaborator": user})):
@@ -170,13 +170,13 @@ async def add_reviewers(gh, repository, pull_request, number):
                 {"collaborator": user},
             )
             level = result["permission"]
-            logger.debug(f"Permission level: {level}")
+            logger.info(f"Permission level: {level}")
             reviewers.append(user)
 
         # If they have permission, add them
         # https://docs.github.com/en/rest/reference/pulls#request-reviewers-for-a-pull-request
         if reviewers:
-            logger.debug(f"Requesting review from: {reviewers}")
+            logger.info(f"Requesting review from: {reviewers}")
 
             # There is a limit of 15 reviewers, so take the first 15
             await gh.post(
@@ -187,7 +187,7 @@ async def add_reviewers(gh, repository, pull_request, number):
 
         # If not, give them permission and comment
         if non_reviewers:
-            logger.debug(f"Adding collaborators: {non_reviewers}")
+            logger.info(f"Adding collaborators: {non_reviewers}")
 
             # We do not want to give users write permission here, as write
             # permission allows people to submit approving reviews for


### PR DESCRIPTION
This PR does a number of things:

- [x] Change the bot's log level to info so that we can filter out lower-level logs
- [x] Avoid a security issue: we can't run `spack maintainers` from the PR version of Spack. That was originally designed for GitHub actions, which run untrusted, but now that we're running this in a bot, running untrusted code gives PR submitters a way to run anything with the same privileges as `spackbot`. We should not do that.
- [x] Rework the way maintainers are tracked. Instead of adding them directly as repo collaborators on the installation's repo, add them to a team called `maintainers` there, IF it exists. This makes it easier to track who's been added by the bot, and it lets admins of the repo control what permissions the collaborators get (e.g., they can do `triage`, which is not handled by the GitHub API yet)
- [x] Fix issues with the private key when running this bot as a container -- specifically, fix escaping and quoting on the private key.