### PR TITLE
Only add 'update-package' label for packages

### DIFF
--- a/spackbot/pr_add_labels.py
+++ b/spackbot/pr_add_labels.py
@@ -46,7 +46,10 @@ label_patterns = {
         "filename": r"^var/spack/repos/builtin/packages/[^/]+/package.py$",
         "status": r"^added$",
     },
-    "update-package": {"status": [r"^modified$", r"^renamed$"]},
+    "update-package": {
+        "filename": r"^var/spack/repos/builtin/packages/[^/]+/package.py$",
+        "status": [r"^modified$", r"^renamed$"]
+    },
     #
     # Variables
     #


### PR DESCRIPTION
The 'update-package' label was being added to PRs that don't update any packages: https://github.com/spack/spack/pull/24590