### PR TITLE
Start of work to provide complete instructions for development

### DIFF
--- a/.env-dummy
+++ b/.env-dummy
@@ -1,0 +1,15 @@
+# Go to smee.io to generate a URL here
+SMEE_URL=https://smee.io/CHANGEME
+
+# You don't need to change this unless you change the docker-compose volumes
+GITHUB_PRIVATE_KEY=/app/spackbot/spack-bot-develop.private-key.pem
+
+# ID of the app on GitHub.
+GITHUB_APP_IDENTIFIER=CHANGEME
+
+# Account the app appears as.
+GITHUB_APP_REQUESTER=CHANGEME
+
+# Secret for webhooks, set when you configured the GitHub app.
+GITHUB_WEBHOOK_SECRET=CHANGEME
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.env
+*.pem
 
 # C extensions
 *.so

--- a/README.md
+++ b/README.md
@@ -29,7 +29,101 @@ The Spackbot process in the container looks at these payloads and reacts to
 them by calling commands through the
 [GitHub API](https://docs.github.com/en/rest).
 
-## Required environment variables
+## Developer Steps with Docker Compose
+
+These steps will walk you through setting up a development server with docker-compose
+and a "smee" service to emulate a URL.
+
+### 1. Create a webhook receiver
+
+Since we are developing and don't have a proper URL to use (a GitHub App setup
+will not accept a localhost address) we need to go to [Smee](https://docs.github.com/en/developers/apps/getting-started-with-apps/setting-up-your-development-environment-to-create-a-github-app#step-1-start-a-new-smee-channel) channel to allow you to register a url that forwards
+to localhost. Once you have a url that looks like this:
+
+```bash
+https://smee.io/VtrVSOmJV7haXpwH
+```
+
+You can proceed to step 2.
+
+### 2. Create secrets
+
+To create your secrets file, copy .env-dummy to .env (which is added to .gitignore)
+and then add your smee URL there:
+
+```bash
+export SMEE_URL=https://smee.io/VtrVSOmJV7haXpwH
+```
+
+The other secrets we will populate after we register the app, discussed next.
+
+### 3. Register a GitHub App
+
+You should next register a [GitHub App](https://github.com/settings/apps) under your username.
+You'll first need to create a  [Follow this link](https://github.com/settings/apps) and click "New GitHub App."
+
+ - **GitHub App Name**: can be whatever you like, SpackBot Develop for example.
+ - **Homepage URL**: you can put the repository here, https://github.com/spack/spack-bot
+ - You don't need to identify or authorize users.
+ - **Webhook URL** enter your smee url
+ - **Repo Permissions** You want to add:
+   - Administration: read and write
+   - Discussions: read and write
+   - Issues: read only
+   - Pull Requests: read and write
+ - **Organization Permissions** none
+   - Members: read and write
+ - **User Permissions** none
+ - **Subscribe to events**: issue comment
+ - It's safer to select to run only on your user account.
+ 
+After you create the App you will be redirected to a screen that has the app ID and
+secrets. Make a private key, and copy it to the [spackbot](spackbot) directory
+for the app to see, named as `spack-bot-develop.private-key.pem`.
+
+```bash
+$ cp $DOWNLOADS/download-key.pem spack-bot-develop.private-key.pem
+```
+
+Make sure to add these variables to your .env, specifically adding:
+
+ - GITHUB_PRIVATE_KEY the name of the file in the root here.
+ - GITHUB_APP_IDENTIFIER is the "APP ID" at the top
+ - GITHUB_APP_REQUESTER is your GitHub account
+ - GITHUB_WEBHOOK_SECRET is technically a client secret (that is used for webhooks)
+
+
+### 4. Build and Start containers
+
+You can then ask docker-compose to build:
+
+```bash
+$ docker-compose build
+```
+
+And start your containers!
+
+```bash
+$ docker-compose up -d
+```
+
+You should be able to see logs (and any errors) by way of:
+
+```bash
+$ docker-compose logs
+Attaching to spack-bot_spackbot_1, spack-bot_smee_1
+smee_1      | smee --url https://smee.io/VtrVSOmJV7haXpwH --target http://spackbot --port 8080
+smee_1      | Forwarding https://smee.io/VtrVSOmJV7haXpwH to http://spackbot
+smee_1      | Connected https://smee.io/VtrVSOmJV7haXpwH
+```
+Now you can develop/make changes, and then restart the containers to restart the
+server. Since [spackbot](spackbot) is bound to the app install location in the container,
+your app will update with changes.
+
+
+## Developer Steps with Local Docker
+
+### 1. Required environment variables
 
 To deploy this, you'll need several environment variables set:
 
@@ -43,7 +137,7 @@ In a development environment, you can put these in a `.env` file in the
 directory where you run the app. In production, they should be set as
 secrets in the deployment environment (e.g., Kubernetes secrets).
 
-## Running the application
+### 2. Running the application
 
 1. Get the root of this project in your `PYTHONPATH`
 2. Run this:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.9"
+services:
+  smee:
+    restart: always
+    env_file:
+      - ./.env
+    build:
+      context: .
+      dockerfile: smee/Dockerfile
+
+  spackbot:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+
+    # For development so restart updates server
+    volumes:
+
+      # includes private key
+      - ./spackbot:/app/spackbot
+    env_file:
+      - ./.env
+    links:
+      - smee

--- a/smee/Dockerfile
+++ b/smee/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:16-buster-slim
+
+EXPOSE 8080
+
+WORKDIR /code
+COPY smee/entrypoint.sh /code/entrypoint.sh
+
+RUN npm install --global smee-client
+ENTRYPOINT ["/bin/bash"]
+CMD ["/code/entrypoint.sh"]

--- a/smee/entrypoint.sh
+++ b/smee/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+
+# Options:
+#  -v, --version          output the version number
+#  -u, --url <url>        URL of the webhook proxy service. Default: https://smee.io/new
+#  -t, --target <target>  Full URL (including protocol and path) of the target service the events will forwarded to. Default: http://127.0.0.1:PORT/PATH
+#  -p, --port <n>         Local HTTP server port (default: 3000)
+#  -P, --path <path>      URL path to post proxied requests to` (default: "/")
+# -h, --help             output usage information
+
+# SMEE_URL should come from .env file bound via docker-compose
+printf "smee --url ${SMEE_URL} --target http://spackbot --port 8080\n"
+smee --url ${SMEE_URL} --target http://spackbot --port 8080


### PR DESCRIPTION
This is the start of work to add more details in the README for setting up a development server, and adding docker-compose containers that provide both spackbot and smee (so the user doesn't have to install on their host).

I've tested this up through running the containers and seeing the services start, and I wanted to ask folks here about the best way to develop with the app? I was thinking of making a clone of spack or other dummy repo on my user account, installing the app there, and then developing that way. Is that a reasonable approach?

Signed-off-by: vsoch <vsoch@users.noreply.github.com>