### PR TITLE
Adding ability for spackbot to fix style for some PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,29 @@
+name: SpackBot CI
+
+on:
+  pull_request: []
+
+jobs:
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup black environment
+        run: |
+          conda create -c conda-forge -y -q --name black black
+
+      - name: Check formatting
+        run: |
+          export PATH="/usr/share/miniconda/bin:$PATH"
+          source activate black
+          black --check --diff spackbot
+
+      # Likely only maintainers will work on Spackbot
+      - name: Comment Pull Request
+        if: github.event_name == 'pull_request' && failure()
+        uses: marocchino/sticky-pull-request-comment@v1.1.0
+        with:
+          message: 'Please format your code with [black](https://black.readthedocs.io): `black spackbot`.'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+      # TODO add tests here?

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ with different events.
 |hello| Say hello to spackbot | `@spackbot hello`|
 |help| Ask for help from spackbot | `@spackbot help` or `@spackbot commands`|
 |style| Spackbot will detect a failed style check and tell you how to fix it | |
+|fix style| The command to fix style will run `spack style --fix`| `@spackbot fix style`|
 
 The interactions above are each represented by a Python file in [spackbot](spackbot).
 
@@ -87,6 +88,7 @@ You'll first need to create a  [Follow this link](https://github.com/settings/ap
  - **Repo Permissions** You want to add:
    - Administration: read and write
    - Discussions: read and write
+   - Contents: read and write
    - Issues: read only
    - Pull Requests: read and write
    - checks: read only

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,10 @@
 aiohttp
+requests
 gidgethub
 python_dotenv
 sh
+
+# Add these so we don't want for install
+mypy
+flake8
+isort

--- a/spackbot/__main__.py
+++ b/spackbot/__main__.py
@@ -15,7 +15,7 @@ from dotenv import load_dotenv
 from gidgethub import routing, sansio
 from gidgethub import aiohttp as gh_aiohttp
 
-from . import pr_add_labels, pr_add_reviewers, pr_add_comments, pr_check_style
+from . import pr_add_labels, pr_add_reviewers, pr_add_comments, pr_checks
 
 # take environment variables from .env file (if present)
 load_dotenv()
@@ -32,7 +32,12 @@ PRIVATE_KEY = os.environ.get("GITHUB_PRIVATE_KEY")
 APP_IDENTIFIER = os.environ.get("GITHUB_APP_IDENTIFIER")
 REQUESTER = os.environ.get("GITHUB_APP_REQUESTER")
 
-router = routing.Router(pr_add_labels.router, pr_add_reviewers.router, pr_add_comments.router, pr_check_style.router)
+router = routing.Router(
+    pr_add_labels.router,
+    pr_add_reviewers.router,
+    pr_add_comments.router,
+    pr_checks.router,
+)
 routes = web.RouteTableDef()
 
 
@@ -124,7 +129,7 @@ def fix_private_key():
 
     # If we are given a file, load into variable
     if PRIVATE_KEY and os.path.exists(PRIVATE_KEY):
-        with open(PRIVATE_KEY, 'r') as handle:
+        with open(PRIVATE_KEY, "r") as handle:
             PRIVATE_KEY = handle.read()
 
     if PRIVATE_KEY:
@@ -151,7 +156,7 @@ async def main(request):
         gh = gh_aiohttp.GitHubAPI(session, REQUESTER, oauth_token=token)
 
         # call the appropriate callback for the event
-        await router.dispatch(event, gh, session=session)
+        await router.dispatch(event, gh, session=session, token=token)
 
     # return a "Success"
     return web.Response(status=200)

--- a/spackbot/helpers.py
+++ b/spackbot/helpers.py
@@ -1,0 +1,57 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from io import StringIO
+import contextlib
+import os
+import tempfile
+import gidgethub
+
+"""Shared function helpers that can be used across routes"
+"""
+
+spack_develop_url = "https://github.com/spack/spack"
+
+
+@contextlib.contextmanager
+def temp_dir():
+    """
+    Create a temporary directory, cd into it, destroy it and cd back when done.
+    """
+    pwd = os.getcwd()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        try:
+            os.chdir(temp_dir)
+            yield temp_dir
+        finally:
+            os.chdir(pwd)
+
+
+def run_command(control, cmd, ok_codes=None):
+    """
+    Run a spack or git command and get output and error
+    """
+    ok_codes = ok_codes or [0, 1]
+    res = StringIO()
+    err = StringIO()
+    control(*cmd, _out=res, _err=err, _ok_code=ok_codes)
+    return res.getvalue(), err.getvalue()
+
+
+async def found(coroutine):
+    """
+    Wrapper for coroutines that returns None on 404, result or True otherwise.
+
+    ``True`` is returned if the request was successful but the result would
+    otherwise be ``False``-ish, e.g. if the request returns no content.
+    """
+    try:
+        result = await coroutine
+        return result or True
+    except gidgethub.HTTPException as e:
+        if e.status_code == 404:
+            return None
+        raise

--- a/spackbot/pr_add_comments.py
+++ b/spackbot/pr_add_comments.py
@@ -4,9 +4,13 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import logging
+import os
 import random
 import re
+import requests
 
+from sh.contrib import git
+from .helpers import found, temp_dir, run_command
 from gidgethub import routing
 
 
@@ -39,17 +43,149 @@ You can interact with me in many ways!
 
 - `@spackbot hello`: say hello and get a friendly response back!
 - `@spackbot help` or `@spackbot commands`: see this message 
+- `@spackbot fix style`: ask me to fix a failed style check
 
 I'll also help to label your pull request and assign reviewers!
 If you need help or see there might be an issue with me, open an issue [here](https://github.com/spack/spack-bot/issues)
 """
 
 
+def get_style_message(output):
+    """
+    Given a terminal output, wrap in a message
+    """
+    # The output is limited to what GitHub can store in comments, 65,536 4-byte unicode
+    # total rounded down -300 for text below
+    if len(output) >= 64700:
+        output = output[:64682] + "\n... truncated ..."
+
+    return (
+        """
+I was able to run `spack style --fix` for you!
+
+<details>
+<summary><b>spack style --fix</b></summary>  
+  
+```bash
+%s
+```    
+</details>
+
+Keep in mind that I cannot fix your flake8 or mypy errors, so if you have any you'll need to fix them and update the pull request."""
+        % output
+    )
+
+
+def is_up_to_date(output):
+    """
+    A commit can fail if there are no changes!
+    """
+    return "branch is up to date" in output
+
+
+async def fix_style(event, gh, token):
+    """
+    Respond to a request to fix style.
+
+    We first retrieve metadata about the pull request. If the request comes
+    from anyone with write access to the repository, we commit, and we commit
+    under the identity of the original person that opened the PR.
+    """
+    response = requests.get(event.data["issue"]["pull_request"]["url"])
+    pr = response.json()
+
+    # Get the sender of the PR - do they have write?
+    sender = event.data["sender"]["login"]
+    repository = event.data["repository"]
+    collaborators_url = repository["collaborators_url"]
+
+    # If they don't have write, we don't allow the command
+    if not await found(gh.getitem(collaborators_url, {"collaborator": sender})):
+        logger.info(f"Not found: {sender}")
+        return (
+            "Sorry %s, I cannot do that for you. Only users with write can make this request!"
+            % sender
+        )
+
+    # Tell the user the style fix is going to take a minute or two
+    message = "Let me see if I can fix that for you! This might take a moment..."
+    await gh.post(event.data["issue"]["comments_url"], {}, data={"body": message})
+
+    # Get the username of the original committer
+    user = pr["user"]["login"]
+    email = "%s@users.noreply.github.com" % user
+
+    # Get the branch and pull request url
+    branch = pr["head"]["ref"]
+    clone_url = pr["head"]["repo"]["svn_url"]
+    naked_url = clone_url.replace("https://", "", 1)
+
+    # If for some reason the message below isn't generated?
+    message = "There was a problem running fixes! @spackbot needs a maintainer's help!"
+
+    # At this point, we can clone the repository and make the change
+    with temp_dir() as cwd:
+        git("clone", "-b", branch, clone_url)
+        os.chdir("spack")
+        git("config", "--local", "user.name", user)
+        git("config", "--local", "user.email", email)
+
+        # This will authenticate the push with the app token
+        git(
+            "remote",
+            "set-url",
+            "origin",
+            "https://%s:%s@%s.git" % (user, token, naked_url),
+        )
+
+        # We need to add develop remote for this to work
+        git("remote", "add", "upstream", "https://github.com/spack/spack")
+        git("fetch", "upstream")
+
+        # This won't work if we are already on a develop branch
+        if branch != "develop":
+            git("checkout", "--track", "upstream/develop")
+            git("checkout", branch)
+
+        # Add newly cloned `spack` to PATH
+        os.environ["PATH"] = f"{cwd}/spack/bin:" + os.environ["PATH"]
+        from sh import spack
+
+        # Save the message for the user
+        res, err = run_command(spack, ["--color", "never", "style", "--fix"])
+
+        # If the branch is really old and there is no style command
+        if "Unknown command" in err:
+            return "It looks like your branch is too old to have spack style! Please update it and try again."
+        message = get_style_message(res)
+
+        # Commit (allow for no changes)
+        res, err = run_command(
+            git,
+            ["commit", "-a", "-m", "[spackbot] updating style on behalf of %s" % user],
+        )
+
+        # Continue differently if the branch is up to date or not
+        if is_up_to_date(res):
+            message += "\nI wasn't able to make any changes, but please see the message above for any remaining issues!"
+            return message
+        message += "\nI've updated the branch with isort fixes."
+
+        # Finally, try to push, update the message if permission not allowed
+        try:
+            git("push", "origin", branch)
+        except:
+            message += "\n\nBut it looks like I'm not able to push to your branch. 😭️"
+
+    return message
+
+
 @router.register("issue_comment", action="created")
 @router.register("issue_comment", action="edited")
 async def add_comments(event, gh, *args, session, **kwargs):
-    """Respond to messages to spackbot"""
-
+    """
+    Respond to messages (comments) to spackbot
+    """
     # We can only tell PR and issue comments apart by this field
     if "pull_request" not in event.data["issue"]:
         return
@@ -63,14 +199,19 @@ async def add_comments(event, gh, *args, session, **kwargs):
 
     # @spackbot hello
     message = None
-    if re.search("@spackbot hello", comment):
+    if re.search("@spackbot hello", comment, re.IGNORECASE):
         logger.info(f"Responding to hello message {comment}...")
         message = say_hello()
 
     # @spackbot commands OR @spackbot help
-    elif re.search("@spackbot (commands|help)", comment):
+    elif re.search("@spackbot (commands|help)", comment, re.IGNORECASE):
         logger.debug("Responding to request for help commands.")
         message = commands_message
+
+    elif re.search("@spackbot fix style", comment, re.IGNORECASE):
+        logger.debug("Responding to request to fix style")
+        token = kwargs.get("token")
+        message = await fix_style(event, gh, token)
 
     if message:
         await gh.post(event.data["issue"]["comments_url"], {}, data={"body": message})

--- a/spackbot/pr_add_labels.py
+++ b/spackbot/pr_add_labels.py
@@ -48,7 +48,7 @@ label_patterns = {
     },
     "update-package": {
         "filename": r"^var/spack/repos/builtin/packages/[^/]+/package.py$",
-        "status": [r"^modified$", r"^renamed$"]
+        "status": [r"^modified$", r"^renamed$"],
     },
     #
     # Variables

--- a/spackbot/pr_checks.py
+++ b/spackbot/pr_checks.py
@@ -20,7 +20,7 @@ It looks like you had an issue with style checks! To fix this, you can run:
 $ spack style --fix
 ```
 
-And then update the pull request here.
+And then update the pull request here. Or you can just say `@spackbot fix style` and I'll do it!
 """
 
 


### PR DESCRIPTION
This PR will add the ability for spackbot to fix style on a user's request. There are a few cases of interaction, and not all of them are well handled. I'll do my best to explain here.

## Case 1: Branch on repository where app is installed

This case will work! Since the app has read/write for contents where it is installed, it is allowed to push to the branch. As an example, here is opening a PR with a change that has an isort error. I ask spackbot to fix style, and we can see he commits on my behalf.

![image](https://user-images.githubusercontent.com/814322/125536882-6ee92985-a7b1-4cfd-82e0-e3555af3147c.png)

The second message after the commit shows the output of the run, and spackbot indicates he was able to make the fixes.
The way this works is that we first check that the person making the request has some form of write - this can be a maintainer or the opener of the PR. But then we commit on behalf of the original person that made the PR.

## Case 2: Branch from a fork

If the PR is from a fork (most common) the app doesn't just get write there - it's not the same as a maintainer on the repo getting write for a PR. In this case, the message looks like this:

![image](https://user-images.githubusercontent.com/814322/125537119-b674fdeb-a6f6-43d7-a58c-e228ba6c2456.png)

Spackbot indicates that he isn't able to push to the branch.

The workaround for this would be to actually use the spackbot account and generate ssh credentials, and then add spackbot as a maintainer on the repository where it is installed. Then to git this would just look like a maintainer pushing to the PR, which is allowed.

## Case 3: No changes to be made

In cases where there are flake8 / mypy (which spackbot can't fix) the message on the last line is different to indicate that spackbot couldn't make any changes (no commit changes). 

![image](https://user-images.githubusercontent.com/814322/125538751-cfc5890c-7050-49f1-8d61-8ea2ada021d4.png)


## Edge cases

I'm sure there are more, but here are the ones that I thought of!

1. If the branch the PR is coming from is _really old_ it won't have a spack style command and we can't run it. In this case we tell this to the user and ask them to update.
2. If we are already on a develop branch, since spack style seems to do some comparison to it, we skip checking out the upstream develop. 

## Added permissions

The app needs Contents Read/Write added in order to have permission (via the token) to push back to the repository, but only for branches in the same repo.

## Other Notes

- I'm adding the start of CI - just a test of black (and I also ran it to prettify the code)
- I moved some common function into a .helpers library
- Since functions might need the token, this is now an argument. However I noticed in testing that (since it's used in a git command) it would be printed to the server logs. I'm not too happy about this, so if anyone has other suggests let's chat about it. Using the ssh approach of the spackbot user would make this call unnecessary and could be a fix.
- I added extra dependencies for the style checkers and requests because 1. it would take even longer to bootstrap, and 2. most PRs at this point won't be updated to have that integration (I'm not even sure we've merged it yet). When we add install from binary and it's much faster (and forks have it) we can use this instead.

Anyhoo, this should be a start!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>