### PR TITLE
Adding ability for spackbot to re-run a GitLab CI pipeline

### DIFF
--- a/.env-dummy
+++ b/.env-dummy
@@ -13,3 +13,5 @@ GITHUB_APP_REQUESTER=CHANGEME
 # Secret for webhooks, set when you configured the GitHub app.
 GITHUB_WEBHOOK_SECRET=CHANGEME
 
+# API token to trigger pipelines in Spack GitLab
+GITLAB_TOKEN=CHANGEME

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ with different events.
 |maintainers| Suggest reviewers (package maintainers) for newly opened pull request | |
 |hello| Say hello to spackbot | `@spackbot hello`|
 |help| Ask for help from spackbot | `@spackbot help` or `@spackbot commands`|
+|pipelines| Ask spackbot to re-run a GitLab pipeline | `@spackbot (re-)run pipelines`|
 |style| Spackbot will detect a failed style check and tell you how to fix it | |
 
 The interactions above are each represented by a Python file in [spackbot](spackbot).
@@ -118,7 +119,7 @@ Make sure to add these variables to your .env, specifically adding:
  - GITHUB_APP_IDENTIFIER is the "APP ID" at the top
  - GITHUB_APP_REQUESTER is your GitHub account
  - GITHUB_WEBHOOK_SECRET also needs to be added to your app.
-
+ - GITLAB_TOKEN is a Gitlab API token to interact with the GitLab API to re-run pipelines there.
 
 ### 4. Build and Start containers
 
@@ -160,6 +161,7 @@ To deploy this, you'll need several environment variables set:
 * `GITHUB_PRIVATE_KEY`: Private key created by the GitHub app.
 * `GITHUB_APP_IDENTIFIER`: ID of the app on GitHub.
 * `GITHUB_APP_REQUESTER`: Account the app appears as.
+* `GITLAB_TOKEN`: GitLab API token
 * `GITHUB_WEBHOOK_SECRET`: Secret for webhooks, set when you configured the
   GitHub app.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp
+requests
 gidgethub
 python_dotenv
 sh

--- a/spackbot/__main__.py
+++ b/spackbot/__main__.py
@@ -15,7 +15,13 @@ from dotenv import load_dotenv
 from gidgethub import routing, sansio
 from gidgethub import aiohttp as gh_aiohttp
 
-from . import pr_add_labels, pr_add_reviewers, pr_add_comments, pr_check_style
+from . import (
+    pr_add_labels,
+    pr_add_reviewers,
+    pr_add_comments,
+    pr_check_style,
+    pr_run_pipeline,
+)
 
 # take environment variables from .env file (if present)
 load_dotenv()
@@ -32,7 +38,13 @@ PRIVATE_KEY = os.environ.get("GITHUB_PRIVATE_KEY")
 APP_IDENTIFIER = os.environ.get("GITHUB_APP_IDENTIFIER")
 REQUESTER = os.environ.get("GITHUB_APP_REQUESTER")
 
-router = routing.Router(pr_add_labels.router, pr_add_reviewers.router, pr_add_comments.router, pr_check_style.router)
+router = routing.Router(
+    pr_add_labels.router,
+    pr_add_reviewers.router,
+    pr_add_comments.router,
+    pr_check_style.router,
+    pr_run_pipeline.router,
+)
 routes = web.RouteTableDef()
 
 
@@ -124,7 +136,7 @@ def fix_private_key():
 
     # If we are given a file, load into variable
     if PRIVATE_KEY and os.path.exists(PRIVATE_KEY):
-        with open(PRIVATE_KEY, 'r') as handle:
+        with open(PRIVATE_KEY, "r") as handle:
             PRIVATE_KEY = handle.read()
 
     if PRIVATE_KEY:

--- a/spackbot/helpers.py
+++ b/spackbot/helpers.py
@@ -1,0 +1,65 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from io import StringIO
+import contextlib
+import os
+import tempfile
+import gidgethub
+
+"""Shared function helpers that can be used across routes"
+"""
+
+spack_develop_url = "https://github.com/spack/spack"
+spack_gitlab_url = "https://gitlab.spack.io"
+
+# Spack has project ID 2
+gitlab_spack_project_url = "https://gitlab.spack.io/api/v4/projects/2"
+
+# Aliases for spackbot so spackbot doesn't respond to himself
+aliases = ["spack-bot", "spackbot", "spack-bot-develop"]
+alias_regex = "(%s)" "|".join(aliases)
+
+
+@contextlib.contextmanager
+def temp_dir():
+    """
+    Create a temporary directory, cd into it, destroy it and cd back when done.
+    """
+    pwd = os.getcwd()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        try:
+            os.chdir(temp_dir)
+            yield temp_dir
+        finally:
+            os.chdir(pwd)
+
+
+def run_command(control, cmd, ok_codes=None):
+    """
+    Run a spack or git command and get output and error
+    """
+    ok_codes = ok_codes or [0, 1]
+    res = StringIO()
+    err = StringIO()
+    control(*cmd, _out=res, _err=err, _ok_code=ok_codes)
+    return res.getvalue(), err.getvalue()
+
+
+async def found(coroutine):
+    """
+    Wrapper for coroutines that returns None on 404, result or True otherwise.
+
+    ``True`` is returned if the request was successful but the result would
+    otherwise be ``False``-ish, e.g. if the request returns no content.
+    """
+    try:
+        result = await coroutine
+        return result or True
+    except gidgethub.HTTPException as e:
+        if e.status_code == 404:
+            return None
+        raise

--- a/spackbot/pr_add_labels.py
+++ b/spackbot/pr_add_labels.py
@@ -48,7 +48,7 @@ label_patterns = {
     },
     "update-package": {
         "filename": r"^var/spack/repos/builtin/packages/[^/]+/package.py$",
-        "status": [r"^modified$", r"^renamed$"]
+        "status": [r"^modified$", r"^renamed$"],
     },
     #
     # Variables

--- a/spackbot/pr_run_pipeline.py
+++ b/spackbot/pr_run_pipeline.py
@@ -1,0 +1,86 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import logging
+import random
+import requests
+import re
+import os
+
+from .helpers import found, alias_regex, gitlab_spack_project_url, spack_gitlab_url
+from gidgethub import routing
+
+
+logger = logging.getLogger(__name__)
+router = routing.Router()
+
+# We can only make the request with a GITLAB TOKEN
+GITLAB_TOKEN = os.environ.get("GITLAB_TOKEN")
+
+
+async def run_pipeline(event, gh):
+    """
+    Make a request to re-run a pipeline.
+    """
+    # Get the pull request number
+    pr_url = event.data["issue"]["pull_request"]["url"]
+    number = pr_url.split("/")[-1]
+
+    # We need the pull request branch
+    response = requests.get(pr_url)
+    pr = response.json()
+
+    # Get the sender of the PR - do they have write?
+    sender = event.data["sender"]["login"]
+    repository = event.data["repository"]
+    collaborators_url = repository["collaborators_url"]
+
+    # If they don't have write, we don't allow the command
+    if not await found(gh.getitem(collaborators_url, {"collaborator": sender})):
+        logger.info(f"Not found: {sender}")
+        return (
+            "Sorry %s, I cannot do that for you. Only users with write can make this request!"
+            % sender
+        )
+
+    # We need the branch name plus number to assemble the GitLab CI
+    branch = pr["head"]["ref"]
+    branch = "github/pr%s_%s" % (number, branch)
+
+    url = "%s/pipeline?ref=%s" % (gitlab_spack_project_url, branch)
+    headers = {"PRIVATE-TOKEN": GITLAB_TOKEN}
+    response = requests.post(url, headers=headers)
+    result = response.json()
+    if "detailed_status" in result and "details_path" in result["detailed_status"]:
+        url = "%s/%s" % (spack_gitlab_url, result["detailed_status"]["details_path"])
+        return "I've started that [pipeline](%s) for you!" % url
+    return "I had a problem triggering the pipeline."
+
+
+@router.register("issue_comment", action="created")
+@router.register("issue_comment", action="edited")
+async def add_comments(event, gh, *args, session, **kwargs):
+    """Respond to request to re-run pipeline"""
+    # We can only tell PR and issue comments apart by this field
+    if "pull_request" not in event.data["issue"]:
+        return
+
+    # spackbot should not respond to himself!
+    if re.search(alias_regex, event.data["comment"]["user"]["login"]):
+        return
+
+    # Respond with appropriate messages
+    comment = event.data["comment"]["body"]
+
+    # @spackbot run pipeline | @spackbot re-run pipeline
+    message = None
+    if re.search("@spackbot (re-)?run pipeline", comment, re.IGNORECASE):
+        logger.info(f"Responding to request to re-run pipeline...")
+        if not GITLAB_TOKEN:
+            message = "I'm not able to re-run the pipeline now because I don't have authentication."
+        else:
+            message = await run_pipeline(event, gh)
+    if message:
+        await gh.post(event.data["issue"]["comments_url"], {}, data={"body": message})


### PR DESCRIPTION
This PR will add support for asking spackbot to re-run a pipeline! I tested this with cancelled pipelines and the triggers worked. It works by way of checking if the person has write, and if so, allowing them to trigger the endpoint to run the GitLab branch.

I duplicated helpers.py since I needed the found function, which is in the other PR.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>