### PR TITLE
Adding note about spack blame

### DIFF
--- a/spackbot/comments.py
+++ b/spackbot/comments.py
@@ -74,7 +74,12 @@ Are you interested in adopting any of these package(s)? If so, simply add the fo
 ```python
     maintainers = ['{author}']
 ```
-If not, could you contact the developers of this package and see if they are interested? Please don't add maintainers without their consent.
+If not, could you contact the developers of this package and see if they are interested? You can quickly see who has worked on a package with `spack blame`:
 
-_You don't have to be a Spack expert or package developer in order to be a "maintainer", it just gives us a list of users willing to review PRs or debug issues relating to this package. A package can have multiple maintainers; just add a list of GitHub handles of anyone who wants to volunteer._
+```bash
+$ spack blame var/spack/repos/builtin/packages/zlib/package.py
+```
+Thank you for your help! Please don't add maintainers without their consent.
+
+_You don't have to be a Spack expert or package developer in order to be a "maintainer," it just gives us a list of users willing to review PRs or debug issues relating to this package. A package can have multiple maintainers; just add a list of GitHub handles of anyone who wants to volunteer._
 """


### PR DESCRIPTION
Instead of running spack blame and spamming people, we can add a note to the PR opener to use it to find people that have worked on the package. This will close #4.