### PR TITLE
Show blame commands for unmaintained packages

### DIFF
--- a/spackbot/comments.py
+++ b/spackbot/comments.py
@@ -77,7 +77,7 @@ Are you interested in adopting any of these package(s)? If so, simply add the fo
 If not, could you contact the developers of this package and see if they are interested? You can quickly see who has worked on a package with `spack blame`:
 
 ```bash
-$ spack blame var/spack/repos/builtin/packages/zlib/package.py
+$ spack blame {first_package_without_maintainer}
 ```
 Thank you for your help! Please don't add maintainers without their consent.
 

--- a/spackbot/handlers/reviewers.py
+++ b/spackbot/handlers/reviewers.py
@@ -145,9 +145,11 @@ async def add_reviewers(event, gh):
     if unmaintained_pkgs:
         # Ask for maintainers
         # https://docs.github.com/en/rest/reference/issues#create-an-issue-comment
+        unmaintained_pkgs = sorted(unmaintained_pkgs)
         comment_body = comments.no_maintainers_comment.format(
             author=pull_request["user"]["login"],
-            packages_without_maintainers="\n* ".join(sorted(unmaintained_pkgs)),
+            packages_without_maintainers="\n* ".join(unmaintained_pkgs),
+            first_package_without_maintainer=unmaintained_pkgs[0],
         )
         await gh.post(pull_request["comments_url"], {}, data={"body": comment_body})
 


### PR DESCRIPTION
Instead of always using zlib as a blame example, use the actual list of unmaintained packages so contributors can simply copy and paste.