### PR TITLE
Change smoke-tests to new stand-alone-tests label

### DIFF
--- a/spackbot/handlers/labels.py
+++ b/spackbot/handlers/labels.py
@@ -68,7 +68,7 @@ label_patterns = {
     "external-packages": {"patch": r"[+-] +def determine_spec_details\("},
     "libraries": {"patch": r"[+-] +def libs\("},
     "headers": {"patch": r"[+-] +def headers\("},
-    "smoke-tests": {"patch": r"[+-] +def test\("},
+    "stand-alone-tests": {"patch": r"[+-] +def test\("},
     #
     # Core spack
     #


### PR DESCRIPTION
I recently changed the 'smoke-tests' label to 'stand-alone-tests' but did not realize spack-bot knew to label PRs until someone pointed one out to me.

This PR replaces the old label with the new one.