### PR TITLE
Removing requests library as dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 aiohttp
-requests
 gidgethub
 python_dotenv
 sh

--- a/spackbot/comments.py
+++ b/spackbot/comments.py
@@ -4,21 +4,18 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import random
-import requests
 import spackbot.helpers as helpers
 
 
-def tell_joke():
+async def tell_joke(gh):
     """
     Tell a joke to ease the PR tension!
     """
-    response = requests.get(
+    joke = await gh.getitem(
         "https://official-joke-api.appspot.com/jokes/programming/random"
     )
-    if response.status_code == 200:
-        joke = response.json()[0]
-        return f"> {joke['setup']}\n *{joke['punchline']}*\n😄️"
-    return "I'm a little tired now for a joke, but hey, you're funny looking! 😄️"
+    joke = joke[0]
+    return f"> {joke['setup']}\n *{joke['punchline']}*\n😄️"
 
 
 def say_hello():

--- a/spackbot/handlers/pipelines.py
+++ b/spackbot/handlers/pipelines.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import logging
-import requests
 import os
 
 from spackbot.helpers import found, gitlab_spack_project_url, spack_gitlab_url
@@ -28,8 +27,7 @@ async def run_pipeline(event, gh):
     number = pr_url.split("/")[-1]
 
     # We need the pull request branch
-    response = requests.get(pr_url)
-    pr = response.json()
+    pr = await gh.getitem(pr_url)
 
     # Get the sender of the PR - do they have write?
     sender = event.data["sender"]["login"]
@@ -52,8 +50,8 @@ async def run_pipeline(event, gh):
 
     url = f"{gitlab_spack_project_url}/pipeline?ref={branch}"
     headers = {"PRIVATE-TOKEN": GITLAB_TOKEN}
-    response = requests.post(url, headers=headers)
-    result = response.json()
+
+    result = await gh.post(url, headers)
     if "detailed_status" in result and "details_path" in result["detailed_status"]:
         url = f"{spack_gitlab_url}/{result['detailed_status']['details_path']}"
         return f"I've started that [pipeline]({url}) for you!"

--- a/spackbot/handlers/reviewers.py
+++ b/spackbot/handlers/reviewers.py
@@ -5,7 +5,6 @@
 
 import logging
 import re
-import requests
 
 import sh
 from sh.contrib import git
@@ -130,7 +129,7 @@ async def add_reviewers(event, gh):
         number = event.data["number"]
     else:
         pr_url = event.data["issue"]["pull_request"]["url"]
-        pull_request = requests.get(pr_url).json()
+        pull_request = await gh.getitem(pr_url)
         number = pull_request["number"]
 
     repository = event.data["repository"]

--- a/spackbot/handlers/style.py
+++ b/spackbot/handlers/style.py
@@ -6,7 +6,6 @@
 import spackbot.comments as comments
 import spackbot.helpers as helpers
 from sh.contrib import git
-import requests
 import logging
 import os
 import sh
@@ -46,8 +45,7 @@ async def fix_style(event, gh):
     from anyone with write access to the repository, we commit, and we commit
     under the identity of the original person that opened the PR.
     """
-    response = requests.get(event.data["issue"]["pull_request"]["url"])
-    pr = response.json()
+    pr = await gh.getitem(event.data["issue"]["pull_request"]["url"])
 
     # Get the sender of the PR - do they have write?
     sender = event.data["sender"]["login"]
@@ -67,7 +65,7 @@ async def fix_style(event, gh):
     user = pr["user"]["login"]
 
     # We need the user id if the user is before July 18. 2017
-    email = helpers.get_user_email(user)
+    email = await helpers.get_user_email(gh, user)
 
     # We need to use the git url with ssh
     branch = pr["head"]["ref"]

--- a/spackbot/helpers.py
+++ b/spackbot/helpers.py
@@ -8,7 +8,6 @@ from io import StringIO
 import contextlib
 import logging
 import os
-import requests
 import tempfile
 import gidgethub
 
@@ -52,11 +51,11 @@ def temp_dir():
             os.chdir(pwd)
 
 
-def get_user_email(user):
+async def get_user_email(gh, user):
     """
     Given a username, get the correct email based on creation date
     """
-    response = requests.get(f"https://api.github.com/users/{user}").json()
+    response = await gh.getitem(f"https://api.github.com/users/{user}")
     created_at = datetime.strptime(response["created_at"].split("T", 1)[0], "%Y-%m-%d")
     split = datetime.strptime("2017-07-18", "%Y-%m-%d")
     if created_at > split:

--- a/spackbot/routes.py
+++ b/spackbot/routes.py
@@ -83,7 +83,7 @@ async def add_comments(event, gh, *args, session, **kwargs):
     # Hey @spackbot tell me a joke!
     elif helpers.botname in comment and "joke" in comment:
         logger.info(f"Responding to request for joke {comment}...")
-        message = comments.tell_joke()
+        message = await comments.tell_joke(gh)
 
     elif re.search(f"{helpers.botname} fix style", comment, re.IGNORECASE):
         logger.debug("Responding to request to fix style")


### PR DESCRIPTION
This will close #33 I could easily test the style and joke requests. I don't like needing to provide the gh client to the helper functions, but I guess it's not that important.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>