### PR TITLE
commands: add label for new/renamed commands *and* command tests

### DIFF
--- a/spackbot/handlers/labels.py
+++ b/spackbot/handlers/labels.py
@@ -83,8 +83,11 @@ label_patterns = {
         "status": r"^added$",
     },
     "commands": {
-        "filename": r"^lib/spack/spack/cmd/[^/]+.py$",
-        "status": r"^modified$",
+        "filename": [
+            r"^lib/spack/spack/cmd/[^/]+.py$",
+            r"^lib/spack/spack/test/cmd/[^/]+.py$",
+            r"^lib/spack/spack/test/(cmd_extension|commands).py$",
+        ],
     },
     "compilers": {"filename": r"^lib/spack/spack/compiler"},
     "directives": {"filename": r"^lib/spack/spack/directives"},


### PR DESCRIPTION
Closes #38 

The `commands` label was only being added if a command file was modified.  This PR will add it for any status (so we add two labels for a new command).  It also adds the label for command test files.