### PR TITLE
Adding workflow to build and deploy the spack bot container

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -1,0 +1,30 @@
+name: Build and Deploy containers
+
+on:
+  # Always test on pull request
+  pull_request: []
+
+  # Deploy on merge to main
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy-test-containers:
+    runs-on: ubuntu-latest
+    name: Build Spackbot Container
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2        
+
+      - name: Build and Run Test Container
+        run: |
+            docker build -t ghcr.io/spack/spack-bot:latest .
+            docker tag ghcr.io/spack/spack-bot:latest ghcr.io/spack/spack-bot:${GITHUB_SHA::8} 
+
+      - name: Login and Deploy Test Container
+        if: (github.event_name != 'pull_request')
+        run: |
+            docker images
+            echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ secrets.GHCR_USERNAME }} --password-stdin
+            docker push --all-tags ghcr.io/spack/spack-bot


### PR DESCRIPTION
This will deploy to GitHub packages on PR (just build) and merge to main (build and deploy) and always deploy a latest along with a tag "versioned" by the git sha, just in case we need to easily go back to an old one

We will need to add someone's username with access to packages to GHCR_USERNAME in the repository secrets.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>