### PR TITLE
Update checkout action to latest

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Build ${{matrix.dockerfile[2]}} Container
     steps:
       - name: Checkout
-        uses: actions/checkout@v2        
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build and Run Test Container
         run: |


### PR DESCRIPTION
GHA is deprecating nodejs 20 (used in v2). Need at least checkout v5 to get minimum runtime.